### PR TITLE
Add README with usage instructions for daily fiber report

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Parte Diario de Trabajos de Fibra Óptica
+
+Este proyecto proporciona un formulario web para registrar y generar un reporte diario de trabajos de fibra óptica.
+
+## Uso
+1. Abra `index.html` en su navegador web.
+2. Complete los campos solicitados con la información del trabajo: datos del cliente, técnicos, materiales utilizados y fotografías.
+3. Presione **Guardar** para enviar el registro a la hoja de Google configurada en el script.
+4. Opcionalmente, utilice **Generar PDF** para descargar una copia del informe.
+
+El formulario no requiere un servidor; todo se ejecuta de manera local en el navegador. Solo se necesita conexión a Internet para enviar datos a Google Sheets y cargar las bibliotecas externas.
+
+## Contenido del repositorio
+- `index.html`: formulario principal del parte diario.
+- `logo_cliente.png` y `logo_empresa.png`: logotipos utilizados en la cabecera.
+
+## Requisitos
+- Navegador compatible con JavaScript.
+- Conexión a Internet para sincronizar con Google Sheets y cargar librerías externas.


### PR DESCRIPTION
## Summary
- Document setup and usage of the daily fiber work report in `README.md`

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/partediario/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689f6aab6a188322b89033b393018cc7